### PR TITLE
Fix pop() behaviors on MutationDict

### DIFF
--- a/pybald/db/models.py
+++ b/pybald/db/models.py
@@ -386,6 +386,30 @@ class MutationDict(Mutable, dict):
         '''
         self.update(state)
 
+    def pop(self, *pargs, **kargs):
+        """
+        Wrap standard pop() to trigger self.changed()
+        """
+        try:
+            result = super(MutationDict, self).pop(*pargs, **kargs)
+        except Exception:
+            raise
+        else:
+            self.changed()
+            return result
+
+    def popitem(self, *pargs, **kargs):
+        """
+        Wrap standard popitem() to trigger self.changed()
+        """
+        try:
+            result = super(MutationDict, self).popitem(*pargs, **kargs)
+        except Exception:
+            raise
+        else:
+            self.changed()
+            return result
+
 
 class NotFound(NoResultFound):
     '''Generic Not Found Error'''


### PR DESCRIPTION
Calling pop() or popitem() on a MutationDict returns the
value, but does not trigger self.changed(), causing the
removed keys/values to reappear after the next commit
or rollback.

For now, I'm just overriding those methods to trigger
self.change() if they haven't raised an exception, since
they either modify the dict or fail...