### PR TITLE
Fix global name error with redirect URLs

### DIFF
--- a/pybald/core/router.py
+++ b/pybald/core/router.py
@@ -192,7 +192,7 @@ class Router(object):
         # routes (map.redirect)
         if route and route.redirect:
             route_name = '_redirect_{0}'.format(id(route))
-            location = url(route_name, **match)
+            location = url(route_name, **urlvars)
             return Response(location=location,
                             status=route.redirect_status
                             )(environ, start_response)


### PR DESCRIPTION
Use a URL route of the following form:
    urls.redirect('{url:.*}/', '{url}',
                  _redirect_code='301 Moved Permanently')
This yields an error in router.py:
Global name 'match' is not found

This is a regression resulting from a previous commit where 'match'
was renamed to 'urlvars'.  Fix is trivial; just rename the var.