### PR TITLE
Include object with general exception dispatches? (take 2)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,12 +9,15 @@ Release 0.4.0 (???)
 * New application context that lives globally is the config passing mechanism.
 
         from pybald import context
-* Replace FormAlchemy with WTForms as the primary mechanism for form processing and validation
+* Replace FormAlchemy with WTForms as the primary mechanism for form processing
+  and validation
 * Utilize controller and model registry.
-* Global context is on a threadlocal stacked proxy to allow multiple pybald applications in one interpreter.
+* Global context is on a threadlocal stacked proxy to allow multiple pybald
+  applications in one interpreter.
 * Database session is now attached to the app context.
 * Shared application resources (caches etc..) are now registered with the context
-
+* ErrorMiddleware now has a more consistent interface with error controllers,
+  passing the raw exception as a *parg, followed by context-specific **kargs
 
 Release 0.3.2 (March 25, 2015)
 ------------------------------
@@ -38,7 +41,7 @@ Release 0.3.0 (November 2, 2014)
 Release 0.2.8 (June 26, 2014)
 -----------------------------
 
-* Update the webasset-based asset bundler to take input and output paths from 
+* Update the webasset-based asset bundler to take input and output paths from
   the project config file. The new arguments are BUNDLE_SOURCE_PATHS and
   BUNDLE_OUTPUT_PATH. So in the project.py file you might have a config
   that looks like:

--- a/pybald/core/middleware/errors.py
+++ b/pybald/core/middleware/errors.py
@@ -71,7 +71,7 @@ class ErrorMiddleware(object):
             # use that to display the errors
             log.debug("HTTP Exception Thrown {0}".format(err.__class__))
             if self.error_controller:
-                handler = self.error_controller(status_code=err.code, exception=err)
+                handler = self.error_controller(err, status_code=err.code)
 
                 try:
                     # try executing error_handler code
@@ -86,7 +86,7 @@ class ErrorMiddleware(object):
         except Exception as err:
             log.exception("General Exception thrown")
             if self.error_controller:
-                handler = self.error_controller(message=str(err), exception=err)
+                handler = self.error_controller(err, message=str(err))
             else:
                 # create a generic HTTP server Error webob exception
                 handler = exc.HTTPServerError('General Fault')

--- a/pybald/core/middleware/errors.py
+++ b/pybald/core/middleware/errors.py
@@ -86,7 +86,7 @@ class ErrorMiddleware(object):
         except Exception as err:
             log.exception("General Exception thrown")
             if self.error_controller:
-                handler = self.error_controller(message=str(err))
+                handler = self.error_controller(message=str(err), exception=err)
             else:
                 # create a generic HTTP server Error webob exception
                 handler = exc.HTTPServerError('General Fault')


### PR DESCRIPTION
We noticed that PyBald passes the code and the raw exception when dispatching HTTPExceptions to an
error controller, but only a str() for general Exceptions...

This seems inconsistent, and is also problematic for monitoring systems like Sentry that can generate detailed error reports from an Exception object (but not from a basic string repr).

I'm guessing there was something behind the current design, though, probably having to do with avoiding references (and memory leaks) around the exception objects... But maybe we can figure something out that lets us do fancy error reporting without encouraging bad behavior around exception objects?

(Redone as a Pull Request between pass-raw-exceptions and dev-0.4, instead of master!)