### PR TITLE
Fix "applicaion"

### DIFF
--- a/pybald/core/middleware/db_middleware.py
+++ b/pybald/core/middleware/db_middleware.py
@@ -30,7 +30,7 @@ class DbMiddleware(object):
             self.application = application
         else:
             # no pipeline so just generate a generic response
-            self.applicaion = Response()
+            self.application = Response()
 
     def __call__(self, environ, start_response):
         # pass through if no exceptions occur, commit sessions on complete


### PR DESCRIPTION
I have serious deja vu about us fixing this typo, but I just noticed that it still seems to be present in the current Pybald master?