### PR TITLE
Log webob HTTPException messages

### DIFF
--- a/pybald/core/middleware/errors.py
+++ b/pybald/core/middleware/errors.py
@@ -69,9 +69,9 @@ class ErrorMiddleware(object):
             return self.application(environ, start_response)
         # handle HTTP errors
         except exc.HTTPException as err:
+            log.debug(u"{0} Thrown: {1}".format(err.__class__.__name__, err))
             # if the middleware is configured with an error controller
             # use that to display the errors
-            log.debug("HTTP Exception Thrown {0}".format(err.__class__))
             if self.error_controller:
                 handler = self.error_controller(err, status_code=err.code)
 


### PR DESCRIPTION
Currently we're only logging the class of `webob.exc.HTTPException`s, and not the more specific error message the Router is returning.

Any Router exception currently gets logged as:
```
HTTP Exception Thrown <class 'webob.exc.HTTPNotFound'>
```
With this patch allowing something more like:
```
HTTPNotFound Thrown: No URL match
```