### PR TITLE
Add Postgres dialect alias

### DIFF
--- a/pybald/core/models.py
+++ b/pybald/core/models.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm.attributes import (
 from sqlalchemy.orm.util import (
     has_identity
 )
-from sqlalchemy.dialects import postgres as pg
+from sqlalchemy.dialects import postgresql as pg
 
 from pybald import context
 from pybald.util import camel_to_underscore, pluralize

--- a/pybald/core/models.py
+++ b/pybald/core/models.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm.attributes import (
 from sqlalchemy.orm.util import (
     has_identity
 )
+from sqlalchemy.dialects import postgres as pg
 
 from pybald import context
 from pybald.util import camel_to_underscore, pluralize


### PR DESCRIPTION
Add an alias for the Postgres dialect, so that Postgres-specific features can be easily accessed, e.g.

```
from pybald.db import models

myDataColumn = models.Column(models.pg.JSON)
```