### PR TITLE
Eliminate Smarterer-era "can_login" check

### DIFF
--- a/pybald/core/middleware/users.py
+++ b/pybald/core/middleware/users.py
@@ -17,10 +17,7 @@ class UserManager(object):
 
     def __call__(self, environ, start_response):
         session = environ.get('pybald.session', None)
-        if session and session.user and session.user.can_login:
-            environ['REMOTE_USER'] = session.user
-        else:
-            environ['REMOTE_USER'] = None
+        environ['REMOTE_USER'] = session.user
 
         if environ['REMOTE_USER']:
             # Continuously validate user sessions


### PR DESCRIPTION
At some point we added the unconditional check for `user.can_login` specifically for Smarterer, and also added the more generic, optional hook for  `user.valid`, which makes a lot more sense for the "reference implementation" of User Middleware...

Having gone over this with the various teams using PyBald, it seems like we should have ditched `user.can_login` ages ago, but just kind of forgot about it?

I believe only Smarterer/quiz_site relies on the `can_login` behavior currently, and it's been pinned to an ancient version of PyBald (and likely will continue to be that way), so it seems safe to remove from Master.

My only question is, in addition to setting `environ['REMOTE_USER']` to None when `user.valid` exists and is False-y, should we also set session.user to None? Or is that a step too far?