### PR TITLE
Modify statement to achieve Python3 compatibility

### DIFF
--- a/pybald/util/context.py
+++ b/pybald/util/context.py
@@ -12,7 +12,7 @@ class Proxy(object):
         return self._proxied_object
 
     def __dir__(self):
-        return sorted(dir(self.__class__) + self.__dict__.keys() + dir(self._proxied()))
+        return sorted(dir(self.__class__) + list(self.__dict__) + dir(self._proxied()))
 
     def __getattr__(self, attr):
         return getattr(self._proxied(), attr)


### PR DESCRIPTION
I'm working on raising Python3 test coverage.

I noticed a line in the Pybald codebase that's causing my tests to fail with a `TypeError`. List concatenation is failing because `{}.keys()` returns a `dict_keys` object in Python3.